### PR TITLE
Use variantID/secret only when reading - not when posting

### DIFF
--- a/cmd/server/types.go
+++ b/cmd/server/types.go
@@ -3,8 +3,11 @@ package main
 type variant struct {
 	Name          string `json:"name"`
 	Description   string `json:"description"`
+}
+type readVariant struct {
 	VariantID     string `json:"variantId"`
 	Secret        string `json:"secret"`
+	variant
 }
 type androidVariant struct {
 	ProjectNumber string `json:"projectNumber"`

--- a/cmd/server/upsClient.go
+++ b/cmd/server/upsClient.go
@@ -46,13 +46,18 @@ func (client *upsClient) createVariant(json []byte) {
 
 	fmt.Println("Sending", string(json), "to", url)
 
-	req, _ := http.NewRequest("POST", url, bytes.NewBuffer(json))
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(json))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 	httpClient := http.Client{}
-	_, err := httpClient.Do(req)
+	resp, err := httpClient.Do(req)
 
 	if err != nil {
 		fmt.Println("UPS request error", err.Error())
+	} else {
+		defer resp.Body.Close()
+		if resp.StatusCode >= 400 {
+			fmt.Println(resp)
+		}
 	}
 }


### PR DESCRIPTION
When the android_variant composition is used for `HTTP POST` the value of the variantID/secret was empty, which is - of coruse - invalid, resulting in a 400 bad_req response.

Hence for posting/creating we should _not_ send this over the wire

also, added some simple log in case of "error response"